### PR TITLE
Allow service usage in a subpath

### DIFF
--- a/app/src/Admin.vue
+++ b/app/src/Admin.vue
@@ -63,6 +63,7 @@
 
 <script>
   "use strict";
+  import Location from './common/location';
 
   export default {
     name: 'app',
@@ -89,7 +90,7 @@
       login() {
         if(!this.password) return;
         const xhr = new XMLHttpRequest();
-        xhr.open('GET', '/admin/data.json');
+        xhr.open('GET', Location.current() + '/data.json');
         xhr.setRequestHeader("x-passwd", this.password);
         xhr.onload = () => {
           if(xhr.status === 200) {

--- a/app/src/Download/PreviewModal.vue
+++ b/app/src/Download/PreviewModal.vue
@@ -66,7 +66,7 @@
       getPreviewText() {
         this.previewText = '';
         const xhr = new XMLHttpRequest();
-        xhr.open('GET', '//' + document.location.host + this.current.url);
+        xhr.open('GET', this.current.url);
         xhr.onload = () => {
           if(xhr.status === 200) {
             this.previewText = xhr.responseText

--- a/app/src/Upload/store/config.js
+++ b/app/src/Upload/store/config.js
@@ -1,5 +1,6 @@
 'use strict';
 import Vue from 'vue';
+import Location from '../../common/location';
 
 export default {
   namespaced: true,
@@ -17,7 +18,7 @@ export default {
   actions: {
     fetch({commit, }) {
       const xhr = new XMLHttpRequest();
-      xhr.open('GET', '/config.json');
+      xhr.open('GET', Location.current() + 'config.json');
       xhr.onload = () => {
         if(xhr.status === 200) {
           try {

--- a/app/src/Upload/store/upload.js
+++ b/app/src/Upload/store/upload.js
@@ -2,6 +2,7 @@
 import tus from "tus-js-client";
 import uuid from 'uuid/v4';
 import md5 from 'crypto-js/md5';
+import Location from '../../common/location';
 
 function humanFileSize(fileSizeInBytes) {
   let i = -1;
@@ -31,7 +32,7 @@ export default {
 
   getters: {
     shareUrl: state => {
-      return document.location.protocol + '//' + document.location.host + '/' + state.sid;
+      return Location.current() + state.sid;
     },
     percentUploaded: state => {
       return Math.min(
@@ -115,7 +116,7 @@ export default {
             type: file._File.type
           },
           resume: true,
-          endpoint: "/files/",
+          endpoint: Location.current() + "files/",
           fingerprint: (file) => {
             // include sid to prevent duplicate file detection on different session
             return ["tus", state.sid, file.name, file.type, file.size, file.lastModified].join("-");

--- a/app/src/common/location.js
+++ b/app/src/common/location.js
@@ -1,0 +1,37 @@
+"use strict";
+
+export default {
+  current() {
+    let origin = document.location.origin;
+    let path = document.location.pathname;
+
+    return origin + path;
+  },
+
+  strip(count) {
+    count = +count || 0;
+    let origin = document.location.origin;
+    let path = document.location.pathname;
+
+    let parts = path.split('/');
+    while (count-- > 0) {
+      parts.pop();
+    }
+
+    return origin + parts.join('/');
+  },
+
+  tail(count) {
+    count = +count || 0;
+    let path = document.location.pathname;
+
+    let parts = path.split('/');
+    let result = [];
+    while (count-- > 0) {
+      result.push(parts.pop());
+    }
+
+    return result.join('/');
+  }
+
+};

--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -94,8 +94,7 @@ app.get('/:sid', (req, res, next) => {
 
     res.header('Cache-control', 'private, max-age=0, no-cache, no-store, must-revalidate');
     res.json({
-      items: db.get(sid).map(data => {
-        const item = Object.assign(data, {url: `/files/${sid}++${data.key}`});
+      items: db.get(sid).map(item => {
         if(item.metadata.password) {
           return AES.encrypt(JSON.stringify(data), item.metadata.password).toString();
         } else {

--- a/public/html/admin.html
+++ b/public/html/admin.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <title>PsiTransfer Admin</title>
-  <link href="/assets/favicon.ico" rel="icon" type="image/x-icon">
+  <link href="./assets/favicon.ico" rel="icon" type="image/x-icon">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex,nofollow">
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-  <link href="/assets/styles.css" rel="stylesheet">
+  <link href="./assets/styles.css" rel="stylesheet">
 </head>
 
 <body>
@@ -28,8 +28,8 @@
     </div>
   </footer>
 
-  <script src="/app/common.js"></script>
-  <script src="/app/admin.js"></script>
+  <script src="./app/common.js"></script>
+  <script src="./app/admin.js"></script>
 
 </body>
 

--- a/public/html/download.html
+++ b/public/html/download.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <title>PsiTransfer</title>
-  <link href="/assets/favicon.ico" rel="icon" type="image/x-icon">
+  <link href="./assets/favicon.ico" rel="icon" type="image/x-icon">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex,nofollow">
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-  <link href="/assets/styles.css" rel="stylesheet">
+  <link href="./assets/styles.css" rel="stylesheet">
 </head>
 
 <body>
@@ -28,8 +28,8 @@
     </div>
   </footer>
 
-  <script src="/app/common.js"></script>
-  <script src="/app/download.js"></script>
+  <script src="./app/common.js"></script>
+  <script src="./app/download.js"></script>
 
 </body>
 

--- a/public/html/error.html
+++ b/public/html/error.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>PsiTransfer</title>
-  <link href="/assets/favicon.ico" rel="icon" type="image/x-icon"/>
+  <link href="./assets/favicon.ico" rel="icon" type="image/x-icon"/>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex,nofollow">
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
@@ -40,7 +40,7 @@
       </strong>
     </p>
     <p>
-      <a title="New Upload" class="btn btn-sm btn-info" href="/"><i class="fa fa-fw fa-cloud-upload"></i> new upload</a>
+      <a title="New Upload" class="btn btn-sm btn-info" href="./"><i class="fa fa-fw fa-cloud-upload"></i> new upload</a>
     </p>
   </div>
   <footer class="footer">

--- a/public/html/upload.html
+++ b/public/html/upload.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <title>PsiTransfer</title>
-  <link href="/assets/favicon.ico" rel="icon" type="image/x-icon">
+  <link href="./assets/favicon.ico" rel="icon" type="image/x-icon">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex,nofollow">
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-  <link href="/assets/styles.css" rel="stylesheet">
+  <link href="./assets/styles.css" rel="stylesheet">
 </head>
 
 <body>
@@ -30,8 +30,8 @@
     </div>
   </footer>
 
-  <script src="/app/common.js"></script>
-  <script src="/app/upload.js"></script>
+  <script src="./app/common.js"></script>
+  <script src="./app/upload.js"></script>
 
 </body>
 


### PR DESCRIPTION
Currently the service needs to be installed in the root of the domain. This commit allows also the usage of subpaths like https://your-acme.com/pub/share behind proxy.

Tested with a small node proxy on http://localhost:8000/app:

    var express = require('express');
    var proxy = require('http-proxy-middleware');
    
    var onProxyRes = function(proxyRes, req, res) {
      var location = proxyRes.headers.location;
      if (location) {
        var locationRewrite = location.replace(/^(\/[^\/])/, '/app$1')
        console.log('Rewrite location ' + location + ' to ' + locationRewrite);
        proxyRes.headers.location = locationRewrite;
      }
    };
    
    var options = {
            target: 'http://localhost:8080',
            changeOrigin: true,
            pathRewrite: {
                '^/app' : '/',
                '^/app/' : '/'
            },
            onProxyRes: onProxyRes
        };
    
    var appProxy = proxy(options);
    
    var app = express();
    
    app.use('/app', appProxy);
    app.listen(8000);