### PR TITLE
Fixed IE11 download page link not working

### DIFF
--- a/app/src/Download.vue
+++ b/app/src/Download.vue
@@ -120,7 +120,10 @@
         const aEl = document.createElement('a');
         aEl.setAttribute('href', file.url);
         aEl.setAttribute('download', file.metadata.name);
+        aEl.style.display = 'none';
+        document.body.appendChild(aEl);
         aEl.click();
+        aEl.remove();
         file.downloaded = true;
       },
 


### PR DESCRIPTION
'click()' function call doesn't open the link because the element is not added to the DOM
