### PR TITLE
Hide copy to clipboard on one-time download

### DIFF
--- a/app/src/Download.vue
+++ b/app/src/Download.vue
@@ -35,7 +35,7 @@
                 file-icon(:file='file')
               td
                 div.pull-right.btn-group
-                  clipboard.btn.btn-sm.btn-default(:value='baseURI + file.url', @change='copied(file, $event)', :title='$root.lang.copyToClipboard')
+                  clipboard.btn.btn-sm.btn-default(:value='baseURI + file.url', @change='copied(file, $event)', :title='$root.lang.copyToClipboard',v-if="file.previewType")
                     a
                       icon(name="copy")
                   a.btn.btn-sm.btn-default(:title="$root.lang.preview", @click.prevent.stop="preview=file", v-if="file.previewType")


### PR DESCRIPTION
Hi!

For security resons, the copy to clipboard feature is disabled on one-time-download buckets.

This will prevent someone from getting the contents of,  for example a text file without discarding the bucket.